### PR TITLE
Aligning documentation with latest release

### DIFF
--- a/learn.md
+++ b/learn.md
@@ -2687,7 +2687,7 @@ val DateTimeType = ScalarType[DateTime]("DateTime",
     case _ ⇒ Left(DateCoercionViolation)
   },
   coerceInput = {
-    case ast.StringValue(s, _, _) ⇒ parseDate(s)
+    case ast.StringValue(s, _, _, _, _) ⇒ parseDate(s)
     case _ ⇒ Left(DateCoercionViolation)
   })
 ```


### PR DESCRIPTION
Updated `ast.StringValue` usage to show how you'd use it with the latest Sangria release.